### PR TITLE
改正检查用户名是否存在检查的缺陷

### DIFF
--- a/options/check/check.sh
+++ b/options/check/check.sh
@@ -16,7 +16,7 @@
   test $LANGUAGE = 'zh_CN' ||  test $LANGUAGE = 'UTF-8' || printf "Error: OS Language $LANGUAGE \nYou can try to set 'LANG=zh_CN.UTF-8'\nWarning: Query result maybe happen wroing becaue OS not support Chinese Langagues.\n"
 
 # Check USER NAME EXIST.
-  if [ -z ${LCTT_USER} ];then
+  if [ -z "$LCTT_USER" ];then
     echo 'Error: Configure user.name AND user.email.'
   fi
 


### PR DESCRIPTION
将check.sh中检测用户名是否存在时对用户名的引用改为 if [ -z "$LCTT_USER" ]，防止在Ubuntu上出现二元运算符警告