### PR TITLE
修正用户名是否存在检查方式用户名不能有空格的错误

### DIFF
--- a/options/check/check.sh
+++ b/options/check/check.sh
@@ -16,7 +16,7 @@
   test $LANGUAGE = 'zh_CN' ||  test $LANGUAGE = 'UTF-8' || printf "Error: OS Language $LANGUAGE \nYou can try to set 'LANG=zh_CN.UTF-8'\nWarning: Query result maybe happen wroing becaue OS not support Chinese Langagues.\n"
 
 # Check USER NAME EXIST.
-  if [ -z ${LCTT_USER} ];then
+  if [ -z "${LCTT_USER}" ];then
     echo 'Error: Configure user.name AND user.email.'
   fi
 


### PR DESCRIPTION
将用户名是否存在检查方式中对用户名的引用加上引号并保留推荐的大括号，避免用户名中含有空格造成的二元运算符错误
